### PR TITLE
cleanup and output as Epigene.vst

### DIFF
--- a/NewProject.jucer
+++ b/NewProject.jucer
@@ -5,7 +5,7 @@
               pluginFormats="buildAU,buildStandalone,buildUnity,buildVST3"
               pluginVST3Category="Filter,Fx" pluginRTASCategory="1,8192" pluginAAXCategory="1,8192"
               companyWebsite="www.thomasjohnmartinez.com" companyEmail="thomasjohnmartinez.com"
-              pluginManufacturerCode="Tmar">
+              pluginManufacturerCode="Tmar" cppLanguageStandard="17">
   <MAINGROUP id="IHChz6" name="Epigene">
     <GROUP id="{FE967B61-7FFB-C742-A132-B97EE45A398F}" name="images">
       <FILE id="KGk3kw" name="greenThing.png" compile="0" resource="1" file="images/PNG/PNG/greenThing.png"/>
@@ -26,8 +26,8 @@
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" targetName="NewProject"/>
-        <CONFIGURATION isDebug="0" name="Release" targetName="NewProject"/>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="Epigene"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="Epigene"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../Programming/JUCE/modules"/>


### PR DESCRIPTION
previous versions were naming the vst incorrectly on output